### PR TITLE
Add CA Financial Reporter documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# caproject
+# CA Financial Reporter V2
+
+## Goals
+- Modern web-based reporting tool for analyzing client financial data
+- Integrates with Gemini for AI-powered insights
+- Simplifies report creation and distribution
+
+## High-level Features
+- Import and organize transaction data
+- Generate balance sheets and income statements
+- Natural language queries via Gemini
+- Export reports to common formats
+
+## Prerequisites
+- **Node.js** 18 or newer (developed with Node 20)
+- **pnpm** 9 or newer
+
+## Setup
+```bash
+pnpm i   # install dependencies
+pnpm dev # start the development server
+```
+
+## Environment Variables
+Set the following values in your `.env` file:
+- `VITE_GEMINI_API_KEY` – Gemini API key
+- `VITE_GEMINI_ORG_ID` – your organization ID
+
+## Roadmap
+- Beta release with basic reporting
+- Enhanced Gemini integration
+- Additional data source connectors
+
+See the [master specification](docs/master-specification.md) for full details.

--- a/docs/master-specification.md
+++ b/docs/master-specification.md
@@ -1,0 +1,5 @@
+# Master Specification
+
+This document will outline all technical and product requirements for CA Financial Reporter V2.
+
+*Note: The detailed specification is under development and will be expanded in future revisions.*


### PR DESCRIPTION
## Summary
- flesh out README with CA Financial Reporter V2 features
- document prerequisites, setup commands and environment vars
- create placeholder master specification under `docs`

## Testing
- `node -v`
- `pnpm -v`

------
https://chatgpt.com/codex/tasks/task_b_68592c278f8083208a9e1b5021f59b98